### PR TITLE
Fixes bug causing silent videos to crash (no audio track)

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -144,12 +144,14 @@
     //Audio output
     //
     NSArray *audioTracks = [self.asset tracksWithMediaType:AVMediaTypeAudio];
-    self.audioOutput = [AVAssetReaderAudioMixOutput assetReaderAudioMixOutputWithAudioTracks:audioTracks audioSettings:nil];
-    self.audioOutput.alwaysCopiesSampleData = NO;
-    self.audioOutput.audioMix = self.audioMix;
-    if ([self.reader canAddOutput:self.audioOutput])
-    {
-        [self.reader addOutput:self.audioOutput];
+    if (audioTracks.count > 0) {
+      self.audioOutput = [AVAssetReaderAudioMixOutput assetReaderAudioMixOutputWithAudioTracks:audioTracks audioSettings:nil];
+      self.audioOutput.alwaysCopiesSampleData = NO;
+      self.audioOutput.audioMix = self.audioMix;
+      if ([self.reader canAddOutput:self.audioOutput])
+      {
+          [self.reader addOutput:self.audioOutput];
+      }
     }
 
     //


### PR DESCRIPTION
If not accounted for, silent videos (0 audio tracks) would crash on this line:

```
self.audioOutput = [AVAssetReaderAudioMixOutput assetReaderAudioMixOutputWithAudioTracks:audioTracks audioSettings:nil];
```

This implements a simple fix by skipping the audioOutput code when no tracks are present in the video file

```
NSArray *audioTracks = [self.asset tracksWithMediaType:AVMediaTypeAudio];
  if (audioTracks.count > 0) {
    //..do the audio stuffs
  }
```
