### PR TITLE
Fix issues with the videos having orientation hints or video settings not matching input settings

### DIFF
--- a/SDAVAssetExportSession.podspec
+++ b/SDAVAssetExportSession.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SDAVAssetExportSession"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "AVAssetExportSession drop-in replacement with customizable audio&video settings"
   s.description  = <<-DESC
                    AVAssetExportSession drop-in remplacement with customizable audio&video settings.


### PR DESCRIPTION
Two changes to make this library mimic AVAssetExportSession behavior.

BUG: videoComposition.renderSize needs to be the post rotated value.
BEHAVIOR: AVExportSession will center-fit the source video into the output video. Implement the same behavior in SDAVExportSession.