### PR TITLE
progress now only updates with video

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -244,13 +244,12 @@
                 error = YES;
             }
             
-            if (!handled) {
-                lastSamplePresentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
-                self.progress = duration == 0 ? 1 : CMTimeGetSeconds(lastSamplePresentationTime) / duration;
-            }
-
             if (!handled && self.videoOutput == output)
             {
+                // update the video progress
+                lastSamplePresentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+                self.progress = duration == 0 ? 1 : CMTimeGetSeconds(lastSamplePresentationTime) / duration;
+
                 if ([self.delegate respondsToSelector:@selector(exportSession:renderFrame:withPresentationTime:toBuffer:)])
                 {
                     CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)CMSampleBufferGetImageBuffer(sampleBuffer);


### PR DESCRIPTION
This prevents the progress from jumping back and forth between meaning
the audio and video progress.  This will give a clean progress bar that
can be wired to a UI element

Fixes issue #29 