### PR TITLE
Video input settings access

### DIFF
--- a/SDAVAssetExportSession.h
+++ b/SDAVAssetExportSession.h
@@ -72,6 +72,13 @@
 @property (nonatomic, copy) NSURL *outputURL;
 
 /**
+ * The settings used for input video track.
+ *
+ * The dictionary’s keys are from <CoreVideo/CVPixelBuffer.h>.
+ */
+@property (nonatomic, copy) NSDictionary *videoInputSettings;
+
+/**
  * The settings used for encoding the video track.
  *
  * A value of nil specifies that appended output should not be re-encoded.

--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -113,7 +113,7 @@
     // Video output
     //
     if (videoTracks.count > 0) {
-        self.videoOutput = [AVAssetReaderVideoCompositionOutput assetReaderVideoCompositionOutputWithVideoTracks:videoTracks videoSettings:nil];
+        self.videoOutput = [AVAssetReaderVideoCompositionOutput assetReaderVideoCompositionOutputWithVideoTracks:videoTracks videoSettings:self.videoInputSettings];
         self.videoOutput.alwaysCopiesSampleData = NO;
         if (self.videoComposition)
         {


### PR DESCRIPTION
We needed access to the video input settings, currently the library passes in nil, this allowed us to pass in RGBA to make sure that all the pixel buffers we receive are RGBA textures.