### PR TITLE
Remove lock for opengl

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -255,9 +255,7 @@
                     CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)CMSampleBufferGetImageBuffer(sampleBuffer);
                     CVPixelBufferRef renderBuffer = NULL;
                     CVPixelBufferPoolCreatePixelBuffer(NULL, self.videoPixelBufferAdaptor.pixelBufferPool, &renderBuffer);
-                    CVPixelBufferLockBaseAddress(renderBuffer, 0);
                     [self.delegate exportSession:self renderFrame:pixelBuffer withPresentationTime:lastSamplePresentationTime toBuffer:renderBuffer];
-                    CVPixelBufferUnlockBaseAddress(renderBuffer, 0);
                     if (![self.videoPixelBufferAdaptor appendPixelBuffer:renderBuffer withPresentationTime:lastSamplePresentationTime])
                     {
                         error = YES;


### PR DESCRIPTION
CVPixelBufferLockBaseAddress(renderBuffer, 0);
[self.delegate exportSession:self renderFrame:pixelBuffer withPresentationTime:lastSamplePresentationTime toBuffer:renderBuffer];
CVPixelBufferUnlockBaseAddress(renderBuffer, 0);

in our case we use the buffer only on the GPU in that scenario there is no need to call lock, Apple doc has even an important warning against that.
I feel it should not done by default by the library. of course this will break current users that our doing CPU based rendering.

Here is the information from official apple doc:
--------------------------------------------------------------

https://developer.apple.com/library/prerelease/ios/documentation/QuartzCore/Reference/CVPixelBufferRef/index.html#//apple_ref/c/func/CVPixelBufferLockBaseAddress

You must call the CVPixelBufferLockBaseAddress function before accessing pixel data with the CPU, and call the CVPixelBufferUnlockBaseAddress function afterward. If you include the kCVPixelBufferLock_ReadOnly value in the lockFlags parameter when locking the buffer, you must also include it when unlocking the buffer.

IMPORTANT
==========
When accessing pixel data with the GPU, locking is not necessary and can impair performance.
