### PR TITLE
Work around for preferredTransform bug

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -309,6 +309,7 @@
 	CGSize targetSize = CGSizeMake([self.videoSettings[AVVideoWidthKey] floatValue], [self.videoSettings[AVVideoHeightKey] floatValue]);
 	CGSize naturalSize = [videoTrack naturalSize];
 	CGAffineTransform transform = videoTrack.preferredTransform;
+    transform.ty = 0;
 	CGFloat videoAngleInDegree  = atan2(transform.b, transform.a) * 180 / M_PI;
 	if (videoAngleInDegree == 90 || videoAngleInDegree == -90) {
 		CGFloat width = naturalSize.width;

--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -309,7 +309,7 @@
 	CGSize targetSize = CGSizeMake([self.videoSettings[AVVideoWidthKey] floatValue], [self.videoSettings[AVVideoHeightKey] floatValue]);
 	CGSize naturalSize = [videoTrack naturalSize];
 	CGAffineTransform transform = videoTrack.preferredTransform;
-    transform.ty = 0;
+    	transform.ty = 0;
 	CGFloat videoAngleInDegree  = atan2(transform.b, transform.a) * 180 / M_PI;
 	if (videoAngleInDegree == 90 || videoAngleInDegree == -90) {
 		CGFloat width = naturalSize.width;


### PR DESCRIPTION
Talking with an Apple engineer it appears there is a bug in the `preferredTransform` return values.

This PR works around that bug.

Below is part of the conversation I had with the Apple engineer.

> I showed your project to the AV Foundation engineers. 

> As you've seen, after recording with the front camera, the movie file track transform matrix as ?> > reported by ‘videoTrack.preferredTransform' is returning a value of:
> (a=0, b=1, c=1, d=0, tx=0, ty=-560)

> and we suspect that the y-translation value ty=-560 that is returned is a bug.  Our engineers have > filed a bug report (r. 31928389) to investigate this issue. 