### PR TITLE
Only workaround preferredTransform bug in broken case

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -309,7 +309,10 @@
 	CGSize targetSize = CGSizeMake([self.videoSettings[AVVideoWidthKey] floatValue], [self.videoSettings[AVVideoHeightKey] floatValue]);
 	CGSize naturalSize = [videoTrack naturalSize];
 	CGAffineTransform transform = videoTrack.preferredTransform;
-    	transform.ty = 0;
+	// Workaround radar 31928389, see https://github.com/rs/SDAVAssetExportSession/pull/70 for more info
+	if (transform.ty == -560) {
+		transform.ty = 0;
+	}
 	CGFloat videoAngleInDegree  = atan2(transform.b, transform.a) * 180 / M_PI;
 	if (videoAngleInDegree == 90 || videoAngleInDegree == -90) {
 		CGFloat width = naturalSize.width;


### PR DESCRIPTION
When I record a video (using `UIImagePickerController` with `UIImagePickerControllerSourceTypeCamera` and `UIImagePickerControllerCameraCaptureModeVideo`) in **landscape** using the **rear camera** on my device and then try to encode it using this library, `transform.ty` is `1080`, and setting it to 0 causes the encoding to fail. When I record in any of the other 3 camera/orientation combinations (front portrait, front landscape, rear portrait), `transform.ty` is already 0.

The following error is logged to the console:
```
_serverConnectionDiedNotification. Info -- notification=Error Domain=AVFoundationErrorDomain Code=-11819 "Cannot Complete Action" UserInfo={NSLocalizedDescription=Cannot Complete Action, NSLocalizedRecoverySuggestion=Try again later.}, AVPlayer = <AVPlayer: 0x1740139f0>, currentTime = 0.00
[Camera] [CAMCaptureEngine] Received a session runtime error notification  with error: Error Domain=AVFoundationErrorDomain Code=-11819 "Cannot Complete Action" UserInfo={NSLocalizedDescription=Cannot Complete Action, NSLocalizedRecoverySuggestion=Try again later.}
[Camera] [CAMCaptureEngine] Performing recovery from error: Error Domain=AVFoundationErrorDomain Code=-11819 "Cannot Complete Action" UserInfo={NSLocalizedDescription=Cannot Complete Action, NSLocalizedRecoverySuggestion=Try again later.}
[Camera] [CAMCaptureEngine] Attempting to recover from a session runtime error by restarting the AVCaptureSession...
```

I'm unable to reproduce the bug that was referenced in #70, but am attempting to still keep the workaround in place for that specific case. Unfortunately since I can't reproduce it myself, I don't know if there are other broken cases that I am missing.

I tested using an iPhone 7 running iOS 10.3.3, iPod touch 6th gen running iOS 11 beta 4, and iPad 2017 running iOS 11 beta 4, and experienced the same results on all devices.