### PR TITLE
Fix 'if (frameRate)' analyze warning

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -289,7 +289,7 @@
         if (videoCompressionProperties)
         {
             NSNumber *frameRate = [videoCompressionProperties objectForKey:AVVideoAverageNonDroppableFrameRateKey];
-            if (frameRate)
+            if ([frameRate boolValue])
             {
                 trackFrameRate = frameRate.floatValue;
             }


### PR DESCRIPTION
Xcode 9 running on macOS High Sierra issues this warning when analyzing with an attached iOS 11.0.1 iPad:

> Pods/SDAVAssetExportSession/SDAVAssetExportSession.m:292:17: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue

This commit fixes it