### PR TITLE
[b] Recorded video with font camera landscape was cut off

### DIFF
--- a/SDAVAssetExportSession.m
+++ b/SDAVAssetExportSession.m
@@ -313,6 +313,11 @@
 	if (transform.ty == -560) {
 		transform.ty = 0;
 	}
+
+	if (transform.tx == -560) {
+		transform.tx = 0;
+	}
+
 	CGFloat videoAngleInDegree  = atan2(transform.b, transform.a) * 180 / M_PI;
 	if (videoAngleInDegree == 90 || videoAngleInDegree == -90) {
 		CGFloat width = naturalSize.width;


### PR DESCRIPTION
Similar to https://github.com/rs/SDAVAssetExportSession/pull/71. This pull request fixes the video cut-off issue when recording video with front-camera for landscape mode.